### PR TITLE
Configurable Dockerfile location

### DIFF
--- a/build/buildspec.yml
+++ b/build/buildspec.yml
@@ -14,7 +14,7 @@ phases:
     commands:
       - echo Build started on `date`
       - echo Building the Docker image...
-      - docker build -t $REPOSITORY_URI:latest .
+      - docker build -t $REPOSITORY_URI:latest -f ${dockerfile} ${dockerfile_path}
       - docker tag $REPOSITORY_URI:latest $REPOSITORY_URI:$IMAGE_TAG
   post_build:
     commands:

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -24,8 +24,11 @@ module "fargate" {
       memory          = "512"
       replicas        = 3
 
-      registry_retention_count = 15
-      logs_retention_days      = 14
+      registry_retention_count = 15 # Optional. 20 by default
+      logs_retention_days      = 14 # Optional. 30 by default
+
+      dockerfile      = "Dockerfile" # Optional. Dockerfile by default
+      dockerfile_path = "."          # Optional. '.' by default
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -270,9 +270,11 @@ data "template_file" "buildspec" {
   template = "${file("${path.module}/build/buildspec.yml")}"
 
   vars {
-    container_name = "${element(keys(var.services), count.index)}"
-    repository_url = "${element(aws_ecr_repository.this.*.repository_url, count.index)}"
-    region         = "${var.region}"
+    container_name  = "${element(keys(var.services), count.index)}"
+    repository_url  = "${element(aws_ecr_repository.this.*.repository_url, count.index)}"
+    region          = "${var.region}"
+    dockerfile      = "${lookup(var.services[element(keys(var.services), count.index)], "dockerfile", var.dockerfile_default_name)}"
+    dockerfile_path = "${lookup(var.services[element(keys(var.services), count.index)], "dockerfile_path", var.dockerfile_default_path)}"
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -61,3 +61,13 @@ variable "ecr_default_retention_count" {
 variable "services" {
   type = "map"
 }
+
+## Docker
+
+variable "dockerfile_default_name" {
+  default = "Dockerfile"
+}
+
+variable "dockerfile_default_path" {
+  default = "."
+}


### PR DESCRIPTION
Previously, the name and location of the `Dockerfile` was hard-coded. This was an issue because it was impossible to have more than one service running different Docker images since all of them would have matched `./Dockerfile` for their builds.