### PR TITLE
Replace CodePipeline Source trigger from GitHub to ECR

### DIFF
--- a/build/buildspec.yml
+++ b/build/buildspec.yml
@@ -3,26 +3,10 @@ version: 0.2
 phases:
   pre_build:
     commands:
-      - pip install awscli --upgrade --user
-      - echo `aws --version`
-      - echo Logging into Amazon ECR...
-      - $(aws ecr get-login --region ${region} --no-include-email)
-      - REPOSITORY_URI=${repository_url}
-      - IMAGE_TAG=$(echo $CODEBUILD_RESOLVED_SOURCE_VERSION | cut -c 1-7)
-      - echo Entered the pre_build phase...
-  build:
-    commands:
-      - echo Build started on `date`
-      - echo Building the Docker image...
-      - docker build -t $REPOSITORY_URI:latest -f ${dockerfile} ${dockerfile_path}
-      - docker tag $REPOSITORY_URI:latest $REPOSITORY_URI:$IMAGE_TAG
+      - apt-get update && apt-get install jq -y
   post_build:
     commands:
-      - echo Build completed on `date`
-      - echo Pushing the Docker images...
-      - docker push $REPOSITORY_URI:latest
-      - docker push $REPOSITORY_URI:$IMAGE_TAG
-      - echo Writing image definitions file...
-      - printf '[{"name":"${container_name}","imageUri":"%s"}]' $REPOSITORY_URI:$IMAGE_TAG > imagedefinitions.json
+      - REPOSITORY_URI=$(cat imageDetail.json | jq .ImageURI)
+      - printf '[{"name":"${container_name}","imageUri":%s}]' $REPOSITORY_URI > imagedefinitions.json
 artifacts:
   files: imagedefinitions.json

--- a/cloudwatch/ecr-source-event.json
+++ b/cloudwatch/ecr-source-event.json
@@ -1,0 +1,24 @@
+{
+  "source": [
+    "aws.ecr"
+  ],
+  "detail-type": [
+    "AWS API Call via CloudTrail"
+  ],
+  "detail": {
+    "eventSource": [
+      "ecr.amazonaws.com"
+    ],
+    "eventName": [
+      "PutImage"
+    ],
+    "requestParameters": {
+      "repositoryName": [
+        "${ecr_repository_name}"
+      ],
+      "imageTag": [
+        "latest"
+      ]
+    }
+  }
+}

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -2,16 +2,12 @@
 
 ## Usage
 
-First update both `repo_name` and `repo_owner` with a Github repository and valid username respectively
-
-> This probably will change in the future by setting the source as the [ECR repository](https://aws.amazon.com/about-aws/whats-new/2018/11/the-aws-developer-tools-improve-continuous-delivery-support-for-aws-fargate-and-amazon-ecs/) instead of a Github repository
-
-And then, to run this example you need to execute:
+To run this example you need to execute:
 
 ```bash
 $ terraform init
 $ terraform plan
-$ GITHUB_TOKEN=<token> terraform apply
+$ terraform apply
 ```
 
 Note that this example create resources which can cost money (AWS Fargate Services, for example). Run `terraform destroy` when you don't need these resources.

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -13,9 +13,6 @@ module "fargate" {
 
   name = "basic-example"
 
-  repo_name  = "<github_repo_name>" # CHANGE THIS
-  repo_owner = "<github_username>"  # CHANGE THIS
-
   services = {
     api = {
       task_definition = "api.json"
@@ -26,9 +23,6 @@ module "fargate" {
 
       registry_retention_count = 15 # Optional. 20 by default
       logs_retention_days      = 14 # Optional. 30 by default
-
-      dockerfile      = "Dockerfile" # Optional. Dockerfile by default
-      dockerfile_path = "."          # Optional. '.' by default
     }
   }
 }

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -3,7 +3,7 @@ terraform {
 }
 
 provider "aws" {
-  version = "~> 1.52.0"
+  version = "~> 1.54.0"
   region  = "us-east-1"
   profile = "playground"
 }

--- a/policies/codepipeline-role-policy.json
+++ b/policies/codepipeline-role-policy.json
@@ -24,6 +24,15 @@
       "Resource": "*"
     },
     {
+      "Effect": "Allow",
+      "Action": [
+        "ecr:DescribeImages"
+      ],
+      "Resource": [
+        "${ecr_repository_arn}"
+      ]
+    },
+    {
       "Action": [
         "ecs:*",
         "events:DescribeRule",

--- a/policies/events-role-policy.json
+++ b/policies/events-role-policy.json
@@ -1,0 +1,14 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+      {
+          "Effect": "Allow",
+          "Action": [
+              "codepipeline:StartPipelineExecution"
+          ],
+          "Resource": [
+            "${codepipeline_arn}"
+          ]
+      }
+  ]
+}

--- a/policies/events-role.json
+++ b/policies/events-role.json
@@ -1,0 +1,12 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "events.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}

--- a/variables.tf
+++ b/variables.tf
@@ -11,15 +11,6 @@ variable "region" {
   default     = "us-east-1"
 }
 
-variable "repo_name" {
-  description = "Name of the repository. Needed for Continious Deployment for ECS services"
-}
-
-variable "repo_owner" {
-  description = "Owner of the repository"
-  default     = "strvcom"
-}
-
 variable "development_mode" {
   description = "Whether or not create a most robust production-ready infrastructure with ALBs and more than 1 replica"
   default     = false
@@ -60,14 +51,4 @@ variable "ecr_default_retention_count" {
 
 variable "services" {
   type = "map"
-}
-
-## Docker
-
-variable "dockerfile_default_name" {
-  default = "Dockerfile"
-}
-
-variable "dockerfile_default_path" {
-  default = "."
 }


### PR DESCRIPTION
This PR changes how the CodePipeline is triggered. Before it was triggered by a new change pushed into a GitHub repo, which was not ideal since the module was strictly coupled to GitHub and also it was needed to specify a GitHub integration token with the first `terraform apply` (as described in the [Basic example](https://github.com/strvcom/terraform-aws-strv-fargate/tree/master/examples/basic))

Now the trigger for new updates comes from the ECR when a new Docker image is published, so now this modules only cares about updates Docker images and users can delegate other CI/CD processes with a different service like Travis or CircleCI.