### PR TITLE
Slack ChatOps functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ nbproject
 *.atom-*
 .tern-*
 jsconfig.json
+
+functions/**/*.zip

--- a/cloudwatch/codepipeline-source-event.json
+++ b/cloudwatch/codepipeline-source-event.json
@@ -1,0 +1,17 @@
+{
+  "source": [
+    "aws.codepipeline"
+  ],
+  "detail-type": [
+    "CodePipeline Pipeline Execution State Change"
+  ],
+  "detail": {
+    "state": [
+      "STARTED",
+      "FAILED",
+      "SUCCEEDED",
+      "CANCELED"
+    ],
+    "pipeline": ${codepipeline_names}
+  }
+}

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -32,7 +32,7 @@ module "fargate" {
   # ChatOps Lambda function
 
   slack_chatops_enabled = true
-  slack_config         = {
+  slack_config = {
     webhook_url = "https://slack.webhook.url"
     channel     = "some_devops_channel"
     username    = "reporter"

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -28,4 +28,13 @@ module "fargate" {
       # acm_certificate_arn = "arn:......"
     }
   }
+
+  # ChatOps Lambda function
+
+  slack_chatops_enabled = true
+  slack_config         = {
+    webhook_url = "https://slack.webhook.url"
+    channel     = "some_devops_channel"
+    username    = "reporter"
+  }
 }

--- a/functions/slack_chatops/index.js
+++ b/functions/slack_chatops/index.js
@@ -1,0 +1,76 @@
+'use strict'
+
+const https = require('https')
+const { URL } = require('url')
+
+module.exports.handler = async (event, context, cb) => {
+  const { detail, region } = event
+  const { pipeline, state } = detail
+
+  const slackChannel = process.env.SLACK_CHANNEL
+  const slackWebhookUrl = new URL(process.env.SLACK_WEBHOOK_URL)
+  const slackUsername = process.env.SLACK_USERNAME
+
+  const payload = {
+    channel: slackChannel,
+    username: slackUsername,
+    text: 'Fargate Module reporter - New CodePipeline State',
+    attachments: [],
+  }
+
+  const notification = buildNotification(pipeline, state, region)
+  payload.attachments.push(notification)
+
+  const stringifiedPayload = JSON.stringify(payload)
+
+  const options = {
+    host: slackWebhookUrl.host,
+    path: slackWebhookUrl.pathname,
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Content-Length': Buffer.byteLength(stringifiedPayload)
+    },
+    port: 443,
+  }
+
+  return new Promise((resolve, reject) => {
+    const req = https.request(options, () => {
+      return resolve()
+    })
+
+    req.on('error', (e) => {
+      return reject(e)
+    })
+
+    req.write(stringifiedPayload)
+    req.end()
+  }).then(cb).catch(cb)
+}
+
+function buildNotification(pipeline, state, region) {
+  const colors = {
+    SUCCEEDED: 'good',
+    STARTED: '#2178DA', // blue-ish
+    FAILED: 'danger',
+    CANCELED: 'warning',
+  }
+
+  return {
+    color: colors[state] || 'nothing',
+    fallback: `${pipeline} new state: ${state}`,
+    fields: [{
+      title: "Pipeline name",
+      value: pipeline,
+      short: true,
+    }, {
+      title: "State",
+      value: state,
+      short: true,
+    }, {
+      title: "Link to pipeline",
+      value: `https://console.aws.amazon.com/codesuite/codepipeline/pipelines/${pipeline}/view?region=${region}`,
+      short: false,
+    }]
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -422,7 +422,7 @@ data "archive_file" "chatops" {
 }
 
 resource "aws_iam_role" "chatops" {
-  count ="${var.slack_chatops_enabled ? 1 : 0}"
+  count = "${var.slack_chatops_enabled ? 1 : 0}"
 
   name = "${var.name}-${terraform.workspace}-chatops-lambda-role"
 
@@ -430,7 +430,7 @@ resource "aws_iam_role" "chatops" {
 }
 
 resource "aws_iam_role_policy" "chatops" {
-  count ="${var.slack_chatops_enabled ? 1 : 0}"
+  count = "${var.slack_chatops_enabled ? 1 : 0}"
 
   name   = "${var.name}-${terraform.workspace}-chatops-lambda-role-policy"
   role   = "${aws_iam_role.chatops.id}"
@@ -438,7 +438,7 @@ resource "aws_iam_role_policy" "chatops" {
 }
 
 resource "aws_lambda_function" "chatops" {
-  count ="${var.slack_chatops_enabled ? 1 : 0}"
+  count = "${var.slack_chatops_enabled ? 1 : 0}"
 
   filename = "${element(data.archive_file.chatops.*.output_path, count.index)}"
 
@@ -458,7 +458,7 @@ resource "aws_lambda_function" "chatops" {
 }
 
 resource "aws_lambda_permission" "chatops" {
-  count ="${var.slack_chatops_enabled ? 1 : 0}"
+  count = "${var.slack_chatops_enabled ? 1 : 0}"
 
   statement_id  = "${var.name}-${terraform.workspace}-pipeline-executions"
   action        = "lambda:InvokeFunction"
@@ -468,7 +468,7 @@ resource "aws_lambda_permission" "chatops" {
 }
 
 data "template_file" "codepipeline_event" {
-  count ="${var.slack_chatops_enabled ? 1 : 0}"
+  count = "${var.slack_chatops_enabled ? 1 : 0}"
 
   template = "${file("${path.module}/cloudwatch/codepipeline-source-event.json")}"
 
@@ -478,7 +478,7 @@ data "template_file" "codepipeline_event" {
 }
 
 resource "aws_cloudwatch_event_rule" "chatops" {
-  count ="${var.slack_chatops_enabled ? 1 : 0}"
+  count = "${var.slack_chatops_enabled ? 1 : 0}"
 
   name        = "${var.name}-${terraform.workspace}-pipeline-events"
   description = "Amazon CloudWatch Events rule to automatically execute a Lambda function to post messages into a Slack channel when CodePipeline state changes (Succeeded or Failed)."
@@ -487,7 +487,7 @@ resource "aws_cloudwatch_event_rule" "chatops" {
 }
 
 resource "aws_cloudwatch_event_target" "chatops" {
-  count ="${var.slack_chatops_enabled ? 1 : 0}"
+  count = "${var.slack_chatops_enabled ? 1 : 0}"
 
   rule      = "${element(aws_cloudwatch_event_rule.chatops.*.name, count.index)}"
   target_id = "${var.name}-${terraform.workspace}-codepipeline"

--- a/policies/chatops-lambda-role-policy.json
+++ b/policies/chatops-lambda-role-policy.json
@@ -1,0 +1,16 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Resource": [
+        "arn:aws:logs:*:*:*"
+      ],
+      "Action": [
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents"
+      ]
+    }
+  ]
+}

--- a/policies/chatops-lambda-role.json
+++ b/policies/chatops-lambda-role.json
@@ -1,0 +1,12 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "lambda.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}

--- a/variables.tf
+++ b/variables.tf
@@ -47,3 +47,15 @@ variable "ecr_default_retention_count" {
 variable "services" {
   type = "map"
 }
+
+## AWS LAMBDA - CHATOPS variables
+
+variable "slack_chatops_enabled" {
+  description = "Whether or not setup a ChatOps configuration exposing the current state of a CodePipeline execution."
+  default = false
+}
+
+variable "slack_config" {
+  type    = "map"
+  default = {}
+}

--- a/variables.tf
+++ b/variables.tf
@@ -52,7 +52,7 @@ variable "services" {
 
 variable "slack_chatops_enabled" {
   description = "Whether or not setup a ChatOps configuration exposing the current state of a CodePipeline execution."
-  default = false
+  default     = false
 }
 
 variable "slack_config" {


### PR DESCRIPTION
I started thinking about this since I realized that I'm about to start using this module in a real project and I really like that spammy Heroku ChatOps integration with Slack.

it's nice to know when something is really deployed and ready to be used without going to the Heroku dashboard and check it by yourself.

This basically adds that (optional) support of Slack notifications of the current CodePipeline state during a deployment cycle. What do you think? 